### PR TITLE
add bytes decoding in read contract command

### DIFF
--- a/internal/cli/contract_commands.go
+++ b/internal/cli/contract_commands.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -222,6 +223,59 @@ func (c *ReadContractCommand) Execute(ctx context.Context, ee *ExecutionEnvironm
 	}
 
 	er := NewExecutionResult()
+
+	l := md.Fields().Len()
+	for i := 0; i < l; i++ {
+		fd := md.Fields().Get(i)
+		value := dMsg.Get(fd)
+
+		switch fd.Kind() {
+		case protoreflect.BytesKind:
+			b := []byte{}
+			var err error
+
+			opts := fd.Options()
+			if opts != nil {
+				fieldOpts := opts.(*descriptorpb.FieldOptions)
+				ext := koinos.E_KoinosBytesType.TypeDescriptor()
+				enum := fieldOpts.ProtoReflect().Get(ext).Enum()
+
+				switch koinos.BytesType(enum) {
+				case koinos.BytesType_HEX, koinos.BytesType_BLOCK_ID, koinos.BytesType_TRANSACTION_ID:
+					b = []byte(hex.EncodeToString(value.Bytes()))
+					if len(b) == 0 && len(value.Bytes()) != 0 {
+						err = fmt.Errorf("error encoding hex")
+					}
+				case koinos.BytesType_BASE58, koinos.BytesType_CONTRACT_ID, koinos.BytesType_ADDRESS:
+					b = []byte(base58.Encode(value.Bytes()))
+					if len(b) == 0 && len(value.Bytes()) != 0 {
+						err = fmt.Errorf("error encoding base58")
+					}
+				case koinos.BytesType_BASE64:
+					fallthrough
+				default:
+					b = []byte(base64.URLEncoding.EncodeToString(value.Bytes()))
+					if len(b) == 0 && len(value.Bytes()) != 0 {
+						err = fmt.Errorf("error encoding base64")
+					}
+				}
+			} else {
+				b = []byte(base64.URLEncoding.EncodeToString(value.Bytes()))
+				if len(b) == 0 && len(value.Bytes()) != 0 {
+					err = fmt.Errorf("error encoding base64")
+				}
+			}
+
+			if err != nil {
+				return nil, err
+			}
+
+			value = protoreflect.ValueOfBytes(b)
+		}
+
+		// Set the value on the message
+		dMsg.Set(fd, value)
+	}
 
 	b, err := prototext.Marshal(dMsg)
 	if err != nil {


### PR DESCRIPTION
the read contract command was not decoding the bytes coming from the result of the command which was not very user friendly. For example, a proto declared as follow would return a "stringified" array of bytes instead of a "human readable" address:

```proto
message test_address_result {
   bytes address = 1 [(koinos.koinos_bytes_type) = ADDRESS];
}
```

current result:
`address:"\x00\x83[ܫ\xd2>]=|\xf3e\x16\xed\xa1\xfdd\x80\x87\x89M\x9b?\x9d6"`

result with this PR:
`address:"1CyZZpAfViLe6uuJaCWTNwjxd5bPCr47sb"`