### PR TITLE
Add ability to force text prompt

### DIFF
--- a/cmd/cli/interactive/interactive.go
+++ b/cmd/cli/interactive/interactive.go
@@ -30,14 +30,14 @@ type KoinosPrompt struct {
 }
 
 // NewKoinosPrompt creates a new interactive prompt object
-func NewKoinosPrompt(parser *cli.CommandParser, execEnv *cli.ExecutionEnvironment) *KoinosPrompt {
+func NewKoinosPrompt(parser *cli.CommandParser, execEnv *cli.ExecutionEnvironment, forceText bool) *KoinosPrompt {
 	kp := &KoinosPrompt{parser: parser, execEnv: execEnv, latestRevision: -1}
 	kp.gPrompt = prompt.New(kp.executor, kp.completer, prompt.OptionLivePrefix(kp.changeLivePrefix), prompt.OptionCompletionWordSeparator(completer.FilePathCompletionSeparator))
 	kp.fPath = &completer.FilePathCompleter{}
 
 	// Check for terminal unicode support
 	lang := strings.ToUpper(os.Getenv("LANG"))
-	kp.unicodeSupport = strings.Contains(lang, "UTF")
+	kp.unicodeSupport = strings.Contains(lang, "UTF") && !forceText
 
 	// Setup status characters
 	if kp.unicodeSupport {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -23,6 +23,7 @@ const (
 	fileOption             = "file"
 	versionOption          = "version"
 	forceInteractiveOption = "force-interactive"
+	forceTextPromptOption  = "force-text-prompt"
 )
 
 // Default options
@@ -48,6 +49,7 @@ func main() {
 	fileCmd := flag.StringSliceP(fileOption, "f", nil, "File to execute")
 	versionCmd := flag.BoolP(versionOption, "v", false, "Display the version")
 	forceInteractive := flag.BoolP(forceInteractiveOption, "i", false, "Forces interactive mode. Useful for forcing a prompt when using the excute option")
+	forceTextPrompt := flag.BoolP(forceTextPromptOption, "t", false, "Forces text prompt in interactive mode, rather than unicode symbols")
 
 	flag.Parse()
 
@@ -104,7 +106,7 @@ func main() {
 	// Run interactive mode if no commands given, or if forced
 	if *forceInteractive || (*executeCmd == nil && *fileCmd == nil) {
 		// Enter interactive mode
-		p := interactive.NewKoinosPrompt(parser, cmdEnv)
+		p := interactive.NewKoinosPrompt(parser, cmdEnv, *forceTextPrompt)
 		p.Run()
 	}
 }


### PR DESCRIPTION
## Brief description
Add ability to force text (non-unicode) prompt

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

