### PR TITLE
Adds the command `get_account_rc`

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -116,6 +116,7 @@ func NewKoinosCommandSet() *CommandSet {
 	cs.AddCommand(NewCommandDeclaration("read", "Read from a smart contract", false, NewReadCommand, *NewCommandArg("contract-id", StringArg), *NewCommandArg("entry-point", StringArg), *NewCommandArg("arguments", StringArg)))
 	cs.AddCommand(NewCommandDeclaration("register", "Register a smart contract's commands", false, NewRegisterCommand, *NewCommandArg("name", ContractNameArg), *NewCommandArg("address", AddressArg), *NewOptionalCommandArg("abi-filename", FileArg)))
 	cs.AddCommand(NewCommandDeclaration("transfer", "Transfer token from an open wallet to a given address", false, NewTransferCommand, *NewCommandArg("value", AmountArg), *NewCommandArg("to", AddressArg)))
+	cs.AddCommand(NewCommandDeclaration("get_account_rc", "Get the current resource credits for a given address", false, NewGetAccountRcCommand, *NewCommandArg("address", StringArg)))
 	cs.AddCommand(NewCommandDeclaration("set_system_call", "Set a system call to a new contract and entry point", false, NewSetSystemCallCommand, *NewCommandArg("system-call", StringArg), *NewCommandArg("contract-id", AddressArg), *NewCommandArg("entry-point", HexArg)))
 	cs.AddCommand(NewCommandDeclaration("set_system_contract", "Change a contract's permission level between user and system", false, NewSetSystemContractCommand, *NewCommandArg("contract-id", AddressArg), *NewCommandArg("system-contract", BoolArg)))
 	cs.AddCommand(NewCommandDeclaration("session", "Create or manage a transaction session (begin, submit, cancel, or view)", false, NewSessionCommand, *NewCommandArg("command", StringArg)))
@@ -1350,6 +1351,45 @@ func (c *SessionCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) 
 	default:
 		return nil, fmt.Errorf("unknown command %s, options are (begin, submit, cancel, view)", c.Command)
 	}
+
+	return result, nil
+}
+
+// ----------------------------------------------------------------------------
+// GetAccountRcs Command
+// ----------------------------------------------------------------------------
+
+// GetAccountRcCommand is a command that retrieves a given accounts resource credits
+type GetAccountRcCommand struct {
+	Address *string
+}
+
+// NewGetAccountRcCommand creates a new GetAccountRcsCommand object
+func NewGetAccountRcCommand(inv *CommandParseResult) Command {
+	address := inv.Args["address"]
+	return &GetAccountRcCommand{Address: address}
+}
+
+// Execute the retrieval of a given addresses resource credits
+func (c *GetAccountRcCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
+	if !ee.IsOnline() {
+		return nil, fmt.Errorf("%w: cannot get account rcs", cliutil.ErrOffline)
+	}
+
+	address := base58.Decode(*c.Address)
+	if len(address) == 0 {
+		return nil, errors.New("could not parse address")
+	}
+
+	rc, err := ee.RPCClient.GetAccountRc(ctx, address)
+	if err != nil {
+		return nil, err
+	}
+
+	message := fmt.Sprintf("%v rc", rc)
+
+	result := NewExecutionResult()
+	result.AddMessage(message)
 
 	return result, nil
 }

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1373,7 +1373,7 @@ func NewGetAccountRcCommand(inv *CommandParseResult) Command {
 // Execute the retrieval of a given addresses resource credits
 func (c *GetAccountRcCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
 	if !ee.IsOnline() {
-		return nil, fmt.Errorf("%w: cannot get account rcs", cliutil.ErrOffline)
+		return nil, fmt.Errorf("%w: cannot get account rc", cliutil.ErrOffline)
 	}
 
 	address := base58.Decode(*c.Address)


### PR DESCRIPTION
Resolves #146.

## Brief description
Allows a user to retrieve the resource credits from a given address.

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```console
🔐 > get_account_rc 13ssJ2cbx7XvubD3wvhYK689eERv28w6rT
2501770403699 rc

🔐 > disconnect
Disconnected

🚫 🔐 > get_account_rc 13ssJ2cbx7XvubD3wvhYK689eERv28w6rT
wallet is offline: cannot get account rc
```
