### PR TITLE
Implementation of `register_token`

### DIFF
--- a/.koinosrc
+++ b/.koinosrc
@@ -1,2 +1,5 @@
+connect https://api.koinos.io/
+register_token koin 15DJN4a8SgrbGhhGksSBASiSYjGnMU8dGL
+register_token vhp 1AdzuXSpC6K9qtXdCBgD5NUpDNwHjMgrc9
 register pob 159myq5YUhhoVWu3wsHKHiJYKPKGUrGiyv
-register vhp 1AdzuXSpC6K9qtXdCBgD5NUpDNwHjMgrc9
+register name_service 19WxDJ9Kcvx4VqQFkpwVmwVEy1hMuwXtQE

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -12,12 +12,9 @@ import (
 	"strconv"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/koinos/koinos-cli/internal/cliutil"
 	"github.com/koinos/koinos-proto-golang/koinos/chain"
-	"github.com/koinos/koinos-proto-golang/koinos/contracts/token"
 	"github.com/koinos/koinos-proto-golang/koinos/protocol"
 	"github.com/koinos/koinos-util-golang/rpc"
 	"github.com/shopspring/decimal"
@@ -95,7 +92,6 @@ func NewKoinosCommandSet() *CommandSet {
 	cs := NewCommandSet()
 
 	cs.AddCommand(NewCommandDeclaration("address", "Show the currently opened wallet's address", false, NewAddressCommand))
-	cs.AddCommand(NewCommandDeclaration("balance", "Check the balance at an address", false, NewBalanceCommand, *NewOptionalCommandArg("owner", AddressArg)))
 	cs.AddCommand(NewCommandDeclaration("connect", "Connect to an RPC endpoint", false, NewConnectCommand, *NewCommandArg("url", StringArg)))
 	cs.AddCommand(NewCommandDeclaration("close", "Close the currently open wallet (lock also works)", false, NewCloseCommand))
 	cs.AddCommand(NewCommandDeclaration("lock", "Synonym for close", true, NewCloseCommand))
@@ -115,7 +111,7 @@ func NewKoinosCommandSet() *CommandSet {
 	cs.AddCommand(NewCommandDeclaration("rclimit", "Set or show the current rc limit. Give no limit to see current value. Give limit as either mana or a percent (i.e. 80%).", false, NewRcLimitCommand, *NewOptionalCommandArg("limit", StringArg)))
 	cs.AddCommand(NewCommandDeclaration("read", "Read from a smart contract", false, NewReadCommand, *NewCommandArg("contract-id", StringArg), *NewCommandArg("entry-point", StringArg), *NewCommandArg("arguments", StringArg)))
 	cs.AddCommand(NewCommandDeclaration("register", "Register a smart contract's commands", false, NewRegisterCommand, *NewCommandArg("name", ContractNameArg), *NewCommandArg("address", AddressArg), *NewOptionalCommandArg("abi-filename", FileArg)))
-	cs.AddCommand(NewCommandDeclaration("transfer", "Transfer token from an open wallet to a given address", false, NewTransferCommand, *NewCommandArg("value", AmountArg), *NewCommandArg("to", AddressArg)))
+	cs.AddCommand(NewCommandDeclaration("register_token", "Register a token's commands", false, NewRegisterTokenCommand, *NewCommandArg("name", ContractNameArg), *NewCommandArg("address", AddressArg), *NewOptionalCommandArg("symbol", StringArg), *NewOptionalCommandArg("precision", StringArg)))
 	cs.AddCommand(NewCommandDeclaration("set_system_call", "Set a system call to a new contract and entry point", false, NewSetSystemCallCommand, *NewCommandArg("system-call", StringArg), *NewCommandArg("contract-id", AddressArg), *NewCommandArg("entry-point", HexArg)))
 	cs.AddCommand(NewCommandDeclaration("set_system_contract", "Change a contract's permission level between user and system", false, NewSetSystemContractCommand, *NewCommandArg("contract-id", AddressArg), *NewCommandArg("system-contract", BoolArg)))
 	cs.AddCommand(NewCommandDeclaration("session", "Create or manage a transaction session (begin, submit, cancel, or view)", false, NewSessionCommand, *NewCommandArg("command", StringArg)))
@@ -131,80 +127,6 @@ func NewKoinosCommandSet() *CommandSet {
 // ----------------------------------------------------------------------------
 
 // All commands should be implemented here
-
-// ----------------------------------------------------------------------------
-// Balance Command
-// ----------------------------------------------------------------------------
-
-// BalanceCommand is a command that checks the balance of an address
-type BalanceCommand struct {
-	AddressString *string
-}
-
-// NewBalanceCommand creates a new balance object
-func NewBalanceCommand(inv *CommandParseResult) Command {
-	addressString := inv.Args["owner"]
-	return &BalanceCommand{AddressString: addressString}
-}
-
-// Execute fetches the balance
-func (c *BalanceCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
-	if !ee.IsOnline() {
-		return nil, fmt.Errorf("%w: cannot check balance", cliutil.ErrOffline)
-	}
-
-	var address []byte
-	var err error
-
-	// Get current account balance if empty address
-	if c.AddressString == nil {
-		if !ee.IsWalletOpen() {
-			return nil, fmt.Errorf("%w: must give an address", cliutil.ErrWalletClosed)
-		}
-
-		address = ee.Key.AddressBytes()
-	} else {
-		address = base58.Decode(*c.AddressString)
-		if len(address) == 0 {
-			return nil, errors.New("could not parse address")
-		}
-	}
-
-	// Setup command execution environment
-	contractID := base58.Decode(cliutil.KoinContractID)
-	if len(contractID) == 0 {
-		panic("Invalid KOIN contract ID")
-	}
-
-	balance, err := ee.RPCClient.GetAccountBalance(ctx, address, contractID, cliutil.KoinBalanceOfEntry)
-	if err != nil {
-		return nil, err
-	}
-
-	// Build the result
-	dec, err := util.SatoshiToDecimal(balance, cliutil.KoinPrecision)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get Mana
-	mana, err := ee.RPCClient.GetAccountRc(ctx, address)
-	if err != nil {
-		return nil, err
-	}
-
-	// Build the mana result
-	manaDec, err := util.SatoshiToDecimal(mana, cliutil.KoinPrecision)
-	if err != nil {
-		return nil, err
-	}
-
-	er := NewExecutionResult()
-	er.AddMessage(fmt.Sprintf("%v %s", dec, cliutil.KoinSymbol))
-	er.AddMessage(fmt.Sprintf("%v %s", manaDec, cliutil.ManaSymbol))
-
-	return er, nil
-}
 
 // ----------------------------------------------------------------------------
 // Close Command
@@ -1003,116 +925,6 @@ func (c *SleepCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*
 	result := NewExecutionResult()
 	result.AddMessage(fmt.Sprintf("Slept for %s", c.Duration))
 	time.Sleep(c.Duration)
-
-	return result, nil
-}
-
-// ----------------------------------------------------------------------------
-// Transfer
-// ----------------------------------------------------------------------------
-
-// TransferCommand is a command that closes an open wallet
-type TransferCommand struct {
-	Address string
-	Amount  string
-}
-
-// NewTransferCommand creates a new close object
-func NewTransferCommand(inv *CommandParseResult) Command {
-	addressString := inv.Args["to"]
-	return &TransferCommand{Address: *addressString, Amount: *inv.Args["value"]}
-}
-
-// Execute transfers token
-func (c *TransferCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
-	if !ee.IsWalletOpen() {
-		return nil, fmt.Errorf("%w: cannot transfer", cliutil.ErrWalletClosed)
-	}
-
-	if !ee.IsOnline() {
-		return nil, fmt.Errorf("%w: cannot transfer", cliutil.ErrOffline)
-	}
-
-	// Convert the amount to a decimal
-	dAmount, err := decimal.NewFromString(c.Amount)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", cliutil.ErrInvalidAmount, err.Error())
-	}
-
-	// Convert the amount to satoshis
-	sAmount, err := util.DecimalToSatoshi(&dAmount, cliutil.KoinPrecision)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", cliutil.ErrInvalidAmount, err.Error())
-	}
-
-	// Ensure a transfer greater than zero
-	if sAmount <= 0 {
-		minimalAmount, _ := util.SatoshiToDecimal(1, cliutil.KoinPrecision)
-		return nil, fmt.Errorf("%w: cannot transfer %s %s, amount should be greater than minimal %s (1e-%d) %s", cliutil.ErrInvalidAmount, dAmount, cliutil.KoinSymbol, minimalAmount, cliutil.KoinPrecision, cliutil.KoinSymbol)
-	}
-
-	// Setup command execution environment
-	contractID := base58.Decode(cliutil.KoinContractID)
-	if len(contractID) == 0 {
-		panic("Invalid KOIN contract ID")
-	}
-
-	// Fetch the account's balance
-	myAddress := ee.Key.AddressBytes()
-	balance, err := ee.RPCClient.GetAccountBalance(ctx, myAddress, contractID, cliutil.KoinBalanceOfEntry)
-	if err != nil {
-		return nil, err
-	}
-	dBalance, err := util.SatoshiToDecimal(balance, cliutil.KoinPrecision)
-	if err != nil {
-		return nil, err
-	}
-
-	// Ensure a transfer greater than opened account balance
-
-	if balance <= sAmount {
-		return nil, fmt.Errorf("%w: insufficient balance %s %s on opened wallet %s, cannot transfer %s %s", cliutil.ErrInvalidAmount, dBalance, cliutil.KoinSymbol, base58.Encode(myAddress), dAmount, cliutil.KoinSymbol)
-	}
-
-	toAddress := base58.Decode(c.Address)
-	if len(toAddress) == 0 {
-		return nil, errors.New("could not parse address")
-	}
-
-	transferArgs := &token.TransferArguments{
-		From:  myAddress,
-		To:    toAddress,
-		Value: uint64(sAmount),
-	}
-
-	args, err := proto.Marshal(transferArgs)
-	if err != nil {
-		return nil, err
-	}
-
-	op := &protocol.Operation{
-		Op: &protocol.Operation_CallContract{
-			CallContract: &protocol.CallContractOperation{
-				ContractId: contractID,
-				EntryPoint: cliutil.KoinTransferEntry,
-				Args:       args,
-			},
-		},
-	}
-
-	result := NewExecutionResult()
-	result.AddMessage(fmt.Sprintf("Transferring %s %s to %s", dAmount, cliutil.KoinSymbol, c.Address))
-
-	err = ee.Session.AddOperation(op, fmt.Sprintf("Transfer %s %s to %s", dAmount, cliutil.KoinSymbol, c.Address))
-	if err == nil {
-		result.AddMessage("Adding operation to transaction session")
-	}
-	if err != nil {
-		err := ee.SubmitTransaction(ctx, result, op)
-		if err != nil {
-			return nil, fmt.Errorf("cannot transfer, %w", err)
-		}
-	}
 
 	return result, nil
 }

--- a/internal/cli/token_commands.go
+++ b/internal/cli/token_commands.go
@@ -1,0 +1,389 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/koinos/koinos-cli/internal/cliutil"
+	"github.com/koinos/koinos-proto-golang/koinos/contracts/token"
+	"github.com/koinos/koinos-proto-golang/koinos/protocol"
+	util "github.com/koinos/koinos-util-golang"
+	"github.com/koinos/koinos-util-golang/rpc"
+	"github.com/shopspring/decimal"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	TokenBalanceOfEntry   = uint32(0x5c721497)
+	TokenTransferEntry    = uint32(0x27f576ca)
+	TokenTotalSupplyEntry = uint32(0xb0da3934)
+	TokenSymbolEntry      = uint32(0xb76a7ca1)
+	TokenDecimalsEntry    = uint32(0xee80fd2f)
+)
+
+func retrieveSymbol(ctx context.Context, client *rpc.KoinosRPCClient, contractID []byte) (*string, error) {
+	symbolArguments := token.SymbolArguments{}
+
+	args, err := proto.Marshal(&symbolArguments)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ReadContract(ctx, args, contractID, TokenSymbolEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	symbolResult := &token.SymbolResult{}
+	err = proto.Unmarshal(resp.GetResult(), symbolResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &symbolResult.Value, nil
+}
+
+func retrieveDecimals(ctx context.Context, client *rpc.KoinosRPCClient, contractID []byte) (*int, error) {
+	decimalsArguments := token.DecimalsArguments{}
+
+	args, err := proto.Marshal(&decimalsArguments)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ReadContract(ctx, args, contractID, TokenDecimalsEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	decimalsResult := &token.DecimalsResult{}
+	err = proto.Unmarshal(resp.GetResult(), decimalsResult)
+	if err != nil {
+		return nil, err
+	}
+
+	value := int(decimalsResult.Value)
+
+	return &value, nil
+}
+
+func retrieveBalance(ctx context.Context, client *rpc.KoinosRPCClient, contractID []byte, address []byte) (*uint64, error) {
+	balanceOfArguments := token.BalanceOfArguments{}
+	balanceOfArguments.Owner = address
+
+	args, err := proto.Marshal(&balanceOfArguments)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ReadContract(ctx, args, contractID, TokenBalanceOfEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	balanceOfResult := &token.BalanceOfResult{}
+	err = proto.Unmarshal(resp.GetResult(), balanceOfResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &balanceOfResult.Value, nil
+}
+
+// ----------------------------------------------------------------------------
+// RegisterToken
+// ----------------------------------------------------------------------------
+
+// RegisterTokenCommand is a command that registers token commands
+type RegisterTokenCommand struct {
+	Name      string
+	Address   string
+	Symbol    *string
+	Precision *string
+}
+
+// NewRegisterTokenCommand instantiates the command to register tokens
+func NewRegisterTokenCommand(inv *CommandParseResult) Command {
+	return &RegisterTokenCommand{Name: *inv.Args["name"], Address: *inv.Args["address"], Symbol: inv.Args["symbol"], Precision: inv.Args["precision"]}
+}
+
+// Execute registers token commands
+func (c *RegisterTokenCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
+	if (c.Symbol == nil || c.Precision == nil) && !ee.IsOnline() {
+		return nil, fmt.Errorf("%w: cannot retrieve symbol and precision", cliutil.ErrOffline)
+	}
+
+	if ee.Contracts.Contains(c.Name) {
+		return nil, fmt.Errorf("%w: token %s already exists", cliutil.ErrContract, c.Name)
+	}
+
+	_, err := ee.Parser.parseCommandName([]byte(c.Name))
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid characters in token name %s", cliutil.ErrContract, err)
+	}
+
+	contractID := base58.Decode(c.Address)
+	if len(contractID) == 0 {
+		return nil, errors.New("could not parse contract ID")
+	}
+
+	var symbol *string
+	if c.Symbol == nil {
+		symbol, err = retrieveSymbol(ctx, ee.RPCClient, contractID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		symbol = c.Symbol
+	}
+
+	var precision *int
+	if c.Precision == nil {
+		precision, err = retrieveDecimals(ctx, ee.RPCClient, contractID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		precision = new(int)
+		*precision, err = strconv.Atoi(*c.Precision)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	NewBalanceOfCommand := func(inv *CommandParseResult) Command {
+		return NewTokenBalanceCommand(inv, contractID, *precision, *symbol)
+	}
+	cmd := NewCommandDeclaration(fmt.Sprintf("%s.balance_of", c.Name), "Checks the balance at an address", false, NewBalanceOfCommand, *NewOptionalCommandArg("address", AddressArg))
+	ee.Parser.Commands.AddCommand(cmd)
+
+	NewTotalSupplyCommand := func(inv *CommandParseResult) Command {
+		return NewTokenTotalSupplyCommand(inv, contractID, *precision, *symbol)
+	}
+	cmd = NewCommandDeclaration(fmt.Sprintf("%s.total_supply", c.Name), "Checks the token total supply", false, NewTotalSupplyCommand)
+	ee.Parser.Commands.AddCommand(cmd)
+
+	NewTransferCommand := func(inv *CommandParseResult) Command {
+		return NewTokenTransferCommand(inv, contractID, *precision, *symbol)
+	}
+	cmd = NewCommandDeclaration(fmt.Sprintf("%s.transfer", c.Name), "Transfers the token", false, NewTransferCommand, *NewCommandArg("to", AddressArg), *NewCommandArg("amount", AddressArg))
+	ee.Parser.Commands.AddCommand(cmd)
+
+	err = ee.Contracts.Add(c.Name, c.Address, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	er := NewExecutionResult()
+	er.AddMessage(fmt.Sprintf("Token '%s' at address %s registered", c.Name, c.Address))
+	return er, nil
+}
+
+// ----------------------------------------------------------------------------
+// TokenBalance
+// ----------------------------------------------------------------------------
+
+// TokenBalanceCommand is a command that retrieves the balance of a particular token
+type TokenBalanceCommand struct {
+	Address    *string
+	ContractID []byte
+	Precision  int
+	Symbol     string
+}
+
+// NewTokenBalanceCommand instantiates the command to retrieve a token balance
+func NewTokenBalanceCommand(inv *CommandParseResult, contractID []byte, precision int, symbol string) Command {
+	return &TokenBalanceCommand{Address: inv.Args["address"], ContractID: contractID, Precision: precision, Symbol: symbol}
+}
+
+// Execute retrieves token balance
+func (c *TokenBalanceCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
+	if !ee.IsOnline() {
+		return nil, fmt.Errorf("%w: cannot check balance", cliutil.ErrOffline)
+	}
+
+	var address []byte
+	if c.Address == nil {
+		if !ee.IsWalletOpen() {
+			return nil, fmt.Errorf("%w: must give an address", cliutil.ErrWalletClosed)
+		}
+
+		address = ee.Key.AddressBytes()
+	} else {
+		address = base58.Decode(*c.Address)
+		if len(address) == 0 {
+			return nil, errors.New("could not parse address")
+		}
+	}
+
+	balance, err := retrieveBalance(ctx, ee.RPCClient, c.ContractID, address)
+	if err != nil {
+		return nil, err
+	}
+
+	dec, err := util.SatoshiToDecimal(*balance, c.Precision)
+	if err != nil {
+		return nil, err
+	}
+
+	er := NewExecutionResult()
+	er.AddMessage(fmt.Sprintf("%v %s", dec, c.Symbol))
+
+	return er, nil
+}
+
+// ----------------------------------------------------------------------------
+// TokenTotalSupply
+// ----------------------------------------------------------------------------
+
+// TokenTotalSupplyCommand is a command that retrieves the total supply of a particular token
+type TokenTotalSupplyCommand struct {
+	ContractID []byte
+	Precision  int
+	Symbol     string
+}
+
+// NewTokenTotalSupplyCommand instantiates the command to retrieve the total supply of a token
+func NewTokenTotalSupplyCommand(inv *CommandParseResult, contractID []byte, precision int, symbol string) Command {
+	return &TokenTotalSupplyCommand{ContractID: contractID, Precision: precision, Symbol: symbol}
+}
+
+// Execute retrieves the token total supply
+func (c *TokenTotalSupplyCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
+	if !ee.IsOnline() {
+		return nil, fmt.Errorf("%w: cannot check total supply", cliutil.ErrOffline)
+	}
+
+	totalSupplyArguments := token.TotalSupplyArguments{}
+
+	args, err := proto.Marshal(&totalSupplyArguments)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := ee.RPCClient.ReadContract(ctx, args, c.ContractID, TokenTotalSupplyEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	totalSupplyResult := &token.TotalSupplyResult{}
+	err = proto.Unmarshal(resp.GetResult(), totalSupplyResult)
+	if err != nil {
+		return nil, err
+	}
+
+	dec, err := util.SatoshiToDecimal(totalSupplyResult.GetValue(), c.Precision)
+	if err != nil {
+		return nil, err
+	}
+
+	er := NewExecutionResult()
+	er.AddMessage(fmt.Sprintf("%v %s", dec, c.Symbol))
+
+	return er, nil
+}
+
+// ----------------------------------------------------------------------------
+// TokenTransfer
+// ----------------------------------------------------------------------------
+
+// TokenTransferCommand is a command that transfers tokens
+type TokenTransferCommand struct {
+	Address    string
+	Amount     string
+	ContractID []byte
+	Precision  int
+	Symbol     string
+}
+
+// NewTokenTransferCommand instantiates the command to transfer tokens
+func NewTokenTransferCommand(inv *CommandParseResult, contractID []byte, precision int, symbol string) Command {
+	return &TokenTransferCommand{Address: *inv.Args["to"], Amount: *inv.Args["amount"], ContractID: contractID, Precision: precision, Symbol: symbol}
+}
+
+// Execute the token transfer
+func (c *TokenTransferCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*ExecutionResult, error) {
+	if !ee.IsWalletOpen() {
+		return nil, fmt.Errorf("%w: cannot transfer", cliutil.ErrWalletClosed)
+	}
+
+	if !ee.IsOnline() {
+		return nil, fmt.Errorf("%w: cannot transfer", cliutil.ErrOffline)
+	}
+
+	decimalAmount, err := decimal.NewFromString(c.Amount)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", cliutil.ErrInvalidAmount, err.Error())
+	}
+
+	satoshiAmount, err := util.DecimalToSatoshi(&decimalAmount, c.Precision)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", cliutil.ErrInvalidAmount, err.Error())
+	}
+
+	if satoshiAmount <= 0 {
+		minimalAmount, _ := util.SatoshiToDecimal(1, c.Precision)
+		return nil, fmt.Errorf("%w: cannot transfer %s %s, amount should be greater than minimal %s (1e-%d) %s", cliutil.ErrInvalidAmount, decimalAmount, c.Symbol, minimalAmount, c.Precision, c.Symbol)
+	}
+
+	walletAddress := ee.Key.AddressBytes()
+
+	balance, err := retrieveBalance(ctx, ee.RPCClient, c.ContractID, walletAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	decimalBalance, err := util.SatoshiToDecimal(*balance, c.Precision)
+	if err != nil {
+		return nil, err
+	}
+
+	if *balance <= satoshiAmount {
+		return nil, fmt.Errorf("%w: insufficient balance %s %s on opened wallet %s, cannot transfer %s %s", cliutil.ErrInvalidAmount, decimalBalance, c.Symbol, base58.Encode(walletAddress), decimalAmount, c.Symbol)
+	}
+
+	toAddress := base58.Decode(c.Address)
+	if len(toAddress) == 0 {
+		return nil, errors.New("could not parse address")
+	}
+
+	transferArgs := &token.TransferArguments{
+		From:  walletAddress,
+		To:    toAddress,
+		Value: uint64(satoshiAmount),
+	}
+
+	args, err := proto.Marshal(transferArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	op := &protocol.Operation{
+		Op: &protocol.Operation_CallContract{
+			CallContract: &protocol.CallContractOperation{
+				ContractId: c.ContractID,
+				EntryPoint: TokenTransferEntry,
+				Args:       args,
+			},
+		},
+	}
+
+	result := NewExecutionResult()
+	result.AddMessage(fmt.Sprintf("Transferring %s %s to %s", decimalAmount, c.Symbol, c.Address))
+
+	err = ee.Session.AddOperation(op, fmt.Sprintf("Transfer %s %s to %s", decimalAmount, c.Symbol, c.Address))
+	if err == nil {
+		result.AddMessage("Adding operation to transaction session")
+	}
+	if err != nil {
+		err := ee.SubmitTransaction(ctx, result, op)
+		if err != nil {
+			return nil, fmt.Errorf("cannot transfer, %w", err)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/cli/token_commands.go
+++ b/internal/cli/token_commands.go
@@ -169,7 +169,7 @@ func (c *RegisterTokenCommand) Execute(ctx context.Context, ee *ExecutionEnviron
 	NewTransferCommand := func(inv *CommandParseResult) Command {
 		return NewTokenTransferCommand(inv, contractID, *precision, *symbol)
 	}
-	cmd = NewCommandDeclaration(fmt.Sprintf("%s.transfer", c.Name), "Transfers the token", false, NewTransferCommand, *NewCommandArg("to", AddressArg), *NewCommandArg("amount", AddressArg))
+	cmd = NewCommandDeclaration(fmt.Sprintf("%s.transfer", c.Name), "Transfers the token", false, NewTransferCommand, *NewCommandArg("to", AddressArg), *NewCommandArg("amount", AmountArg))
 	ee.Parser.Commands.AddCommand(cmd)
 
 	err = ee.Contracts.Add(c.Name, c.Address, nil, nil)


### PR DESCRIPTION
Resolves #143.
Resolves #144.
Resolves #145.

## Brief description
Adds `register_token` command which allows the user to add tokens considering their symbol and precision. Removes the hardcoded `transfer` and `balance` commands.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./koinos-cli
Connected to endpoint https://api.koinos.io/

Token 'koin' at address 15DJN4a8SgrbGhhGksSBASiSYjGnMU8dGL registered

Token 'vhp' at address 1AdzuXSpC6K9qtXdCBgD5NUpDNwHjMgrc9 registered

Contract 'pob' at address 159myq5YUhhoVWu3wsHKHiJYKPKGUrGiyv registered

Contract 'name_service' at address 19WxDJ9Kcvx4VqQFkpwVmwVEy1hMuwXtQE registered

Koinos CLI v1.0.0
Type "list" for a list of commands, "help <command>" for help on a specific command.
🔐 > vhp.total_supply
7759501.02489313 VHP

🔐 > koin.total_supply
9557584.57649814 KOIN

🔐 > koin.balance_of 1NsQbH5AhQXgtSNg1ejpFqTi2hmCWz1eQS
6977.43290515 KOIN

🔐 > vhp.balance_of 1NsQbH5AhQXgtSNg1ejpFqTi2hmCWz1eQS
2197976.10563429 VHP

...

🔓 > tkoin.transfer 1Kv5E6ZSJbJxNtDCy2dLTNqJoT1fLvpukP 0.1
Transferring 0.1 tKOIN to 1Kv5E6ZSJbJxNtDCy2dLTNqJoT1fLvpukP
Transaction with ID 0x1220dd0e8f7d3989a4a007e8bbc340a409822cd47bcafd5828ee684098be6af66a7a containing 1 operations submitted.
Mana cost: 0.10904102 (Disk: 112, Network: 313, Compute: 561569)

🔓 > tkoin.balance_of
9999.9 tKOIN

🔓 > tkoin.balance_of 1Kv5E6ZSJbJxNtDCy2dLTNqJoT1fLvpukP
0.1 tKOIN

🔓 > tkoin.total_supply
19658634.79195013 tKOIN
```
