### PR TITLE
Fix regex string for AddressArg and add error msg for invalid address format

### DIFF
--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -153,7 +153,7 @@ func NewCommandParser(commands *CommandSet) *CommandParser {
 	parser.commandNameRE = regexp.MustCompile(fmt.Sprintf(`^(%s+\.)?%s+`, CommandNameTokens, CommandNameTokens))
 	parser.skipRE = regexp.MustCompile(`^\s*`)
 	parser.terminatorRE = regexp.MustCompile(`^(;|$)`)
-	parser.addressRE = regexp.MustCompile(`^[1-9A-HJ-NP-Za-km-z]+`)
+	parser.addressRE = regexp.MustCompile(`^[1][a-km-zA-HJ-NP-Z1-9]{32,34}$`)
 	parser.simpleStringRE = regexp.MustCompile(`^[^\s"\';]+`)
 	parser.amountRE = regexp.MustCompile(`^((\d+(\.\d*)?)|(\.\d+))`)
 	parser.uintRE = regexp.MustCompile(`^[+]?[0-9]+`)
@@ -311,7 +311,7 @@ func (p *CommandParser) parseAddress(input []byte) ([]byte, int, error) {
 	// Parse address
 	m := p.addressRE.Find(input)
 	if m == nil {
-		return nil, 0, fmt.Errorf("%w", cliutil.ErrInvalidParam)
+		return nil, 0, fmt.Errorf("%w", cliutil.ErrInvalidAddrFormat)
 	}
 
 	return m, len(m), nil

--- a/internal/cliutil/errors.go
+++ b/internal/cliutil/errors.go
@@ -61,4 +61,7 @@ var (
 
 	// ErrContract is returned when a contract is already registered
 	ErrContract = errors.New("contract error")
+
+	// ErrInvalidAddrFormat is returned when an address is in invalid format
+	ErrInvalidAddrFormat = errors.New("invalid address format")
 )


### PR DESCRIPTION
Resolves #138 
Resolves #131 

## Brief description
The regular expression string for all `AddressArg` was allowing things to pass as addresses that shouldn't be. This should fix the problem for all addresses that use this.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration

Before:

![image](https://user-images.githubusercontent.com/23157604/202494004-33dce411-8c5a-4296-b1e0-6650d07b1b3d.png)


After:

![image](https://user-images.githubusercontent.com/23157604/202493636-2929a39a-722a-4455-80e0-2082f9d07e97.png)

