### PR TITLE
Do not display a warning when the .env file does not exist

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -37,11 +37,8 @@ const (
 )
 
 func main() {
-	// Load .env file
-	err := godotenv.Load()
-	if err != nil {
-		fmt.Println(err)
-	}
+	// Optionally load .env file
+	godotenv.Load()
 
 	// Setup command line options
 	rpcAddress := flag.StringP(rpcOption, "r", rpcDefault, "RPC server URL")

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -38,7 +38,7 @@ const (
 
 func main() {
 	// Optionally load .env file
-	godotenv.Load()
+	_ = godotenv.Load()
 
 	// Setup command line options
 	rpcAddress := flag.StringP(rpcOption, "r", rpcDefault, "RPC server URL")


### PR DESCRIPTION
Resolves #153.

## Brief description
Removes the warning when the `.env` does not exist.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./koinos-cli/build/koinoscli
Connected to endpoint https://api.koinos.io/

Token 'koin' at address 15DJN4a8SgrbGhhGksSBASiSYjGnMU8dGL registered

Token 'vhp' at address 1AdzuXSpC6K9qtXdCBgD5NUpDNwHjMgrc9 registered

Contract 'pob' at address 159myq5YUhhoVWu3wsHKHiJYKPKGUrGiyv registered

Contract 'name_service' at address 19WxDJ9Kcvx4VqQFkpwVmwVEy1hMuwXtQE registered

Koinos CLI v1.0.0
Type "list" for a list of commands, "help <command>" for help on a specific command.
🔐 > exit
```
