### PR TITLE
Remove the double spacing of `.koinosrc` execution results

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -96,10 +96,21 @@ func main() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+
+		results := make([]string, 0)
+
 		lines := strings.Split(string(data), "\n")
 		for _, line := range lines {
-			results := cli.ParseAndInterpret(parser, cmdEnv, line)
-			results.Print()
+			ir := cli.ParseAndInterpret(parser, cmdEnv, line)
+			results = append(results, ir.Results...)
+		}
+
+		for _, result := range results {
+			fmt.Println(result)
+		}
+
+		if len(results) > 0 {
+			fmt.Println()
 		}
 	}
 


### PR DESCRIPTION
Resolves #155.

## Brief description
Removes the double spacing of `.koinosrc` execution results.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./koinoscli
Connected to endpoint https://api.koinos.io/
Token 'koin' at address 15DJN4a8SgrbGhhGksSBASiSYjGnMU8dGL registered
Token 'vhp' at address 1AdzuXSpC6K9qtXdCBgD5NUpDNwHjMgrc9 registered
Contract 'pob' at address 159myq5YUhhoVWu3wsHKHiJYKPKGUrGiyv registered
Contract 'name_service' at address 19WxDJ9Kcvx4VqQFkpwVmwVEy1hMuwXtQE registered

Koinos CLI v1.0.0
Type "list" for a list of commands, "help <command>" for help on a specific command.
🔐 >
```
