### PR TITLE
#122: Handle enums and fix panic on empty list in return

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/ethereum/go-ethereum v1.10.9 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/koinos/go-prompt v0.0.0-20220818181004-5b1028a45a2f
-	github.com/koinos/koinos-proto-golang v1.0.0
-	github.com/koinos/koinos-util-golang v1.0.0
+	github.com/koinos/koinos-proto-golang v1.0.1-0.20221123003957-336b725f600d
+	github.com/koinos/koinos-util-golang v1.0.1-0.20221123010835-d34cde17793e
 	github.com/minio/sio v0.3.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,12 @@ github.com/koinos/go-prompt v0.0.0-20220818181004-5b1028a45a2f h1:b7s6B0NyISu+/Z
 github.com/koinos/go-prompt v0.0.0-20220818181004-5b1028a45a2f/go.mod h1:Q5ndhnCeUQKAlYSUuBwte5tJxSTopTRmRs0kSl9vmMY=
 github.com/koinos/koinos-proto-golang v1.0.0 h1:N8haj+tMRLc/a1j636wjryoaxW+aJwKKSdZ01CRJoOU=
 github.com/koinos/koinos-proto-golang v1.0.0/go.mod h1:ZonOOdmZcuEbRdOqqdfYRA2I4szYHy5aKzUveMWXBog=
+github.com/koinos/koinos-proto-golang v1.0.1-0.20221123003957-336b725f600d h1:IgJ7WzGRVwe2/XJfPwK/YxUAy7LubjhbMSDeCgy6sHU=
+github.com/koinos/koinos-proto-golang v1.0.1-0.20221123003957-336b725f600d/go.mod h1:ZonOOdmZcuEbRdOqqdfYRA2I4szYHy5aKzUveMWXBog=
 github.com/koinos/koinos-util-golang v1.0.0 h1:OIwBG7L8dLFh3xWwyE2EYd9XRnhH3UnwboddOX1j86w=
 github.com/koinos/koinos-util-golang v1.0.0/go.mod h1:E7vZAMfTX7I3r+nKvbO08YsKDb3YxyuVaKV04Kuf3AI=
+github.com/koinos/koinos-util-golang v1.0.1-0.20221123010835-d34cde17793e h1:JQcwtDe/rQe+2nBuApk/Xc97zbC4EYs11d/e8A+vTgw=
+github.com/koinos/koinos-util-golang v1.0.1-0.20221123010835-d34cde17793e/go.mod h1:Vh7/QpPKO0wvq0W2MRAXilhKG8PM3tRXGD9Jtqi0IDs=
 github.com/koinos/protobuf-go v1.27.2-0.20211026185306-2456c83214fe h1:PJ+2AnN4ibN2WxldiClplZZosQNPnXj7S5vOeFNtV+M=
 github.com/koinos/protobuf-go v1.27.2-0.20211026185306-2456c83214fe/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -476,7 +476,7 @@ func (c *ImportCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (
 	}
 
 	// Create the key
-	key, err := util.NewKoinosKeysFromBytes(keyBytes)
+	key, err := util.NewKoinosKeyFromBytes(keyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -722,7 +722,7 @@ func (c *OpenCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*E
 	}
 
 	// Create the key object
-	key, err := util.NewKoinosKeysFromBytes(keyBytes)
+	key, err := util.NewKoinosKeyFromBytes(keyBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/contract_commands.go
+++ b/internal/cli/contract_commands.go
@@ -253,6 +253,10 @@ func (c *ReadContractCommand) Execute(ctx context.Context, ee *ExecutionEnvironm
 			value = protoreflect.ValueOfBytes(b)
 		}
 
+		if fd.IsList() && value.List().Len() == 0 {
+			continue
+		}
+
 		// Set the value on the message
 		dMsg.Set(fd, value)
 	}


### PR DESCRIPTION
Resolves #122

## Brief description

Adds remaining chain proto files when parsing ABI files, handles enums from ABI files, and fixes a panic handling an empty list in a contract return.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
Koinos CLI v1.0.0
Type "list" for a list of commands, "help <command>" for help on a specific command.
🔐 > register governance 19qj51eTbSFJYU7ZagudkpxPgNSzPMfdPX contracts/governance.abi
Contract 'governance' at address 19qj51eTbSFJYU7ZagudkpxPgNSzPMfdPX registered

🔐 > governance.get_proposals 0x00 0

🔐 > register resources 1HGN9h47CzoFwU2bQZwe6BYoX4TM6pXc4b
Contract 'resources' at address 1HGN9h47CzoFwU2bQZwe6BYoX4TM6pXc4b registered

🔐 > resources.get_resource_limits
value:  {
  disk_storage_limit:  524288
  disk_storage_cost:  10308
  network_bandwidth_limit:  1048576
  network_bandwidth_cost:  1560
  compute_bandwidth_limit:  287500000
  compute_bandwidth_cost:  8
}

```
