### PR TITLE
Remove extra padding around `chain_id` command output

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -910,7 +910,7 @@ func (c *ChainIDCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) 
 			if err != nil {
 				return nil, err
 			}
-			result.AddMessage(fmt.Sprintf("Chain ID: auto ( %s )", base64.URLEncoding.EncodeToString(chainID)))
+			result.AddMessage(fmt.Sprintf("Chain ID: auto (%s)", base64.URLEncoding.EncodeToString(chainID)))
 		} else {
 			result.AddMessage(fmt.Sprintf("Chain ID: %s", ee.chainID))
 		}


### PR DESCRIPTION
Resolves #176.

## Brief description
Remove extraneous padding around the `chain_id` command.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
Koinos CLI v1.0.0
Type "list" for a list of commands, "help <command>" for help on a specific command.
🔐 > chain_id
Chain ID: auto (EiBZK_GGVP0H_fXVAM3j6EAuz3-B-l3ejxRSewi7qIBfSA==)
```
