### PR TITLE
Crash on contract read

### DIFF
--- a/internal/cli/contract_commands.go
+++ b/internal/cli/contract_commands.go
@@ -204,7 +204,10 @@ func (c *ReadContractCommand) Execute(ctx context.Context, ee *ExecutionEnvironm
 
 	er := NewExecutionResult()
 
-	DecodeMessageBytes(dMsg, md)
+	err = DecodeMessageBytes(dMsg, md)
+	if err != nil {
+		return nil, err
+	}
 
 	b, err := text.MarshalPretty(dMsg)
 	if err != nil {
@@ -216,7 +219,7 @@ func (c *ReadContractCommand) Execute(ctx context.Context, ee *ExecutionEnvironm
 	return er, nil
 }
 
-func DecodeMessageBytes(dMsg *dynamicpb.Message, md protoreflect.MessageDescriptor) (protoreflect.Message, error) {
+func DecodeMessageBytes(dMsg *dynamicpb.Message, md protoreflect.MessageDescriptor) error {
 	l := md.Fields().Len()
 	for i := 0; i < l; i++ {
 		modified := false
@@ -238,7 +241,7 @@ func DecodeMessageBytes(dMsg *dynamicpb.Message, md protoreflect.MessageDescript
 				case koinos.BytesType_HEX, koinos.BytesType_BLOCK_ID, koinos.BytesType_TRANSACTION_ID:
 					b, err = hex.DecodeString(string(value.Bytes()))
 					if err != nil {
-						return nil, err
+						return err
 					}
 				case koinos.BytesType_BASE58, koinos.BytesType_CONTRACT_ID, koinos.BytesType_ADDRESS:
 					b = base58.Decode(string(value.Bytes()))
@@ -248,13 +251,13 @@ func DecodeMessageBytes(dMsg *dynamicpb.Message, md protoreflect.MessageDescript
 				default:
 					b, err = base64.URLEncoding.DecodeString(string(value.Bytes()))
 					if err != nil {
-						return nil, err
+						return err
 					}
 				}
 			} else {
 				b, err = base64.URLEncoding.DecodeString(string(value.Bytes()))
 				if err != nil {
-					return nil, err
+					return err
 				}
 			}
 
@@ -272,7 +275,7 @@ func DecodeMessageBytes(dMsg *dynamicpb.Message, md protoreflect.MessageDescript
 		}
 	}
 
-	return dMsg, nil
+	return nil
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #173

## Brief description
Fix the crash when reading some contracts

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
Reading a nonexisting proposal now correctly return empty message

```
🔐 > governance.get_proposal_by_id 0x01


🔐 > resources.get_resource_limits
value:  {
  disk_storage_limit:  524288
  disk_storage_cost:  21896
  network_bandwidth_limit:  1048576
  network_bandwidth_cost:  3314
  compute_bandwidth_limit:  287500000
  compute_bandwidth_cost:  17
}
```