### PR TITLE
Change default RC limit to 10%, show more helpful error messages

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -386,7 +386,7 @@ func (c *UploadContractCommand) Execute(ctx context.Context, ee *ExecutionEnviro
 	if err != nil {
 		err := ee.SubmitTransaction(ctx, result, op)
 		if err != nil {
-			return nil, fmt.Errorf("cannot upload contract, %w", err)
+			return result, fmt.Errorf("cannot upload contract, %w", err)
 		}
 	}
 
@@ -653,7 +653,7 @@ func (c *SubmitTransactionCommand) Execute(ctx context.Context, ee *ExecutionEnv
 
 	receipt, err := ee.RPCClient.SubmitTransaction(ctx, transaction, true)
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 
 	result.AddMessage(cliutil.TransactionReceiptToString(receipt, len(transaction.GetOperations())))
@@ -727,7 +727,7 @@ func (c *CallCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) (*E
 	if err != nil {
 		err := ee.SubmitTransaction(ctx, result, op)
 		if err != nil {
-			return nil, fmt.Errorf("cannot call contract, %w", err)
+			return result, fmt.Errorf("cannot call contract, %w", err)
 		}
 	}
 
@@ -1192,7 +1192,7 @@ func (c *SetSystemCallCommand) Execute(ctx context.Context, ee *ExecutionEnviron
 	if err != nil {
 		err := ee.SubmitTransaction(ctx, result, op)
 		if err != nil {
-			return nil, fmt.Errorf("cannot set system call, %w", err)
+			return result, fmt.Errorf("cannot set system call, %w", err)
 		}
 	}
 
@@ -1261,7 +1261,7 @@ func (c *SetSystemContractCommand) Execute(ctx context.Context, ee *ExecutionEnv
 	if err != nil {
 		err := ee.SubmitTransaction(ctx, result, op)
 		if err != nil {
-			return nil, fmt.Errorf("cannot set contract, %w", err)
+			return result, fmt.Errorf("cannot set contract, %w", err)
 		}
 	}
 
@@ -1359,7 +1359,7 @@ func (c *SessionCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) 
 			} else {
 				err := ee.SubmitTransaction(ctx, result, ops...)
 				if err != nil {
-					return nil, fmt.Errorf("error submitting transaction, %w", err)
+					return result, fmt.Errorf("error submitting transaction, %w", err)
 				}
 			}
 		} else {

--- a/internal/cli/contract_commands.go
+++ b/internal/cli/contract_commands.go
@@ -347,7 +347,7 @@ func (c *WriteContractCommand) Execute(ctx context.Context, ee *ExecutionEnviron
 	if err != nil {
 		err := ee.SubmitTransaction(ctx, result, op)
 		if err != nil {
-			return nil, fmt.Errorf("cannot make call, %w", err)
+			return result, fmt.Errorf("cannot make call, %w", err)
 		}
 	}
 

--- a/internal/cli/interpreter.go
+++ b/internal/cli/interpreter.go
@@ -236,7 +236,10 @@ func (ee *ExecutionEnvironment) SubmitTransaction(ctx context.Context, result *E
 	if err != nil {
 		ee.ResetNonce()
 		if err.Error() == "insufficient rc" {
-			ee.createInsufficientRCMessage(ctx, result)
+			err2 := ee.createInsufficientRCMessage(ctx, result)
+			if err2 != nil {
+				return err2
+			}
 		}
 		return err
 	}
@@ -264,7 +267,7 @@ func (ee *ExecutionEnvironment) createInsufficientRCMessage(ctx context.Context,
 			result.AddErrorMessage(fmt.Sprintf("Current RC limit: %v, RC available: %v", decValue, decRc))
 			result.AddErrorMessage(fmt.Sprintf("Try using a higher RC limit. Example: rclimit %v", decRc))
 		} else {
-			result.AddErrorMessage(fmt.Sprint("You are already using the maximum RC limit, more RC is required to submit this transaction."))
+			result.AddErrorMessage("You are already using the maximum RC limit, more RC is required to submit this transaction.")
 		}
 	} else {
 		if ee.rcLimit.value < 100000000 {
@@ -274,9 +277,9 @@ func (ee *ExecutionEnvironment) createInsufficientRCMessage(ctx context.Context,
 				return err
 			}
 			result.AddErrorMessage(fmt.Sprintf("Current rc limit: %v%%", resultVal))
-			result.AddErrorMessage(fmt.Sprint("Try using a higher RC limit. Example: rclimit 100%"))
+			result.AddErrorMessage("Try using a higher RC limit. Example: rclimit 100%")
 		} else {
-			result.AddErrorMessage(fmt.Sprint("You are already using the maximum RC limit, more RC is required to submit this transaction."))
+			result.AddErrorMessage("You are already using the maximum RC limit, more RC is required to submit this transaction.")
 		}
 	}
 

--- a/internal/cli/interpreter.go
+++ b/internal/cli/interpreter.go
@@ -264,8 +264,15 @@ func (ee *ExecutionEnvironment) createInsufficientRCMessage(ctx context.Context,
 			if err != nil {
 				return err
 			}
+
+			// Generate a suggested value of 2 times decValue, with a max of decRc
+			suggestVal := decimal.NewFromFloat(2).Mul(*decValue)
+			if suggestVal.GreaterThan(*decRc) {
+				suggestVal = *decRc
+			}
+
 			result.AddErrorMessage(fmt.Sprintf("Current RC limit: %v, RC available: %v", decValue, decRc))
-			result.AddErrorMessage(fmt.Sprintf("Try using a higher RC limit. Example: rclimit %v", decRc))
+			result.AddErrorMessage(fmt.Sprintf("Try using a higher RC limit. Example: rclimit %v", suggestVal))
 		} else {
 			result.AddErrorMessage("You are already using the maximum RC limit, more RC is required to submit this transaction.")
 		}
@@ -276,8 +283,15 @@ func (ee *ExecutionEnvironment) createInsufficientRCMessage(ctx context.Context,
 			if err != nil {
 				return err
 			}
+
+			// Generate a suggested value that is 2 times the current value, with a max of 100%
+			suggestVal := decimal.NewFromFloat(2).Mul(*decAmount).Mul(decimal.NewFromFloat(100))
+			if suggestVal.GreaterThan(decimal.NewFromFloat(100)) {
+				suggestVal = decimal.NewFromFloat(100)
+			}
+
 			result.AddErrorMessage(fmt.Sprintf("Current rc limit: %v%%", resultVal))
-			result.AddErrorMessage("Try using a higher RC limit. Example: rclimit 100%")
+			result.AddErrorMessage(fmt.Sprintf("Try using a higher RC limit. Example: rclimit %v%%", suggestVal))
 		} else {
 			result.AddErrorMessage("You are already using the maximum RC limit, more RC is required to submit this transaction.")
 		}

--- a/internal/cli/token_commands.go
+++ b/internal/cli/token_commands.go
@@ -382,7 +382,7 @@ func (c *TokenTransferCommand) Execute(ctx context.Context, ee *ExecutionEnviron
 	if err != nil {
 		err := ee.SubmitTransaction(ctx, result, op)
 		if err != nil {
-			return nil, fmt.Errorf("cannot transfer, %w", err)
+			return result, fmt.Errorf("cannot transfer, %w", err)
 		}
 	}
 

--- a/internal/cliutil/errors.go
+++ b/internal/cliutil/errors.go
@@ -61,4 +61,7 @@ var (
 
 	// ErrContract is returned when a contract is already registered
 	ErrContract = errors.New("contract error")
+
+	// ErrInsufficientRC is returned when not enough resource credits can be used to cover a transaction
+	ErrInsufficientRC = errors.New("insufficient rc")
 )


### PR DESCRIPTION
Resolves #182 

## Brief description
Changes the default rc limit to 10%, and gives more instructive error messages

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```
(online) (unlocked) > rclimit .001
Set rc limit to 0.001

(online) (unlocked) > koin.transfer
missing parameter: to
Usage: koin.transfer <to:address> <amount:amount>

(online) (unlocked) > koin.transfer aaaa 1
cannot transfer, insufficient rc
Current RC limit: 0.001, RC available: 100
Try using a higher RC limit. Example: rclimit .002

(online) (unlocked) > rclimit .001%
Set rc limit to 0.001%

(online) (unlocked) > koin.transfer aaaa 1
cannot transfer, insufficient rc
Current rc limit: 0.001%
Try using a higher RC limit. Example: rclimit 0.002%
```
