### PR TITLE
Output correct JSON format when submitting an offline session

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/koinos/koinos-cli/internal/cliutil"
+	kjson "github.com/koinos/koinos-proto-golang/encoding/json"
 	"github.com/koinos/koinos-proto-golang/koinos/chain"
 	"github.com/koinos/koinos-proto-golang/koinos/protocol"
 	"github.com/shopspring/decimal"
@@ -1342,10 +1344,16 @@ func (c *SessionCommand) Execute(ctx context.Context, ee *ExecutionEnvironment) 
 
 				// Convert to json
 				result.AddMessage("JSON:")
-				txnJSON, err := json.MarshalIndent(txn, "", "  ")
+				unformatedTxnJSON, err := kjson.Marshal(txn)
 				if err != nil {
 					return nil, fmt.Errorf("cannot submit transaction session, %w", err)
 				}
+				buffer := bytes.NewBuffer(make([]byte, 0))
+				err = json.Indent(buffer, unformatedTxnJSON, "", "  ")
+				if err != nil {
+					return nil, fmt.Errorf("cannot submit transaction session, %w", err)
+				}
+				txnJSON := buffer.String()
 				result.AddMessage(string(txnJSON))
 
 				// Convert to base64


### PR DESCRIPTION
## Brief description

When submitting an offline transaction, the resulting JSON did not use the correct encodings for binary data. This PR fixes it to do so.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

Without fix:

```
🚫 🔓 📄 > session submit
JSON:
{
  "id": "EiCEv74qLN53NG6fo+vJUlhgsK7JCDU7wdKtXwYTV6G4gg==",
  "header": {
    "chain_id": "Zm9vYmFy",
    "rc_limit": 1000000000,
    "nonce": "KBQ=",
    "operation_merkle_root": "EiBHEzzpN+hYlXGwlz6Wg+D9IrJmSPRsVr63tNV2SeYMQQ==",
    "payer": "ACISicKuuJib6PEWx9Zag4wm0wDj3z7sGg=="
  },
  "operations": [
    {
      "Op": {
        "CallContract": {
          "contract_id": "AC4z/RqpB7IkzpzmyUIokB0oOgLalW2nkQ==",
          "entry_point": 670398154,
          "args": "ChkAIhKJwq64mJvo8RbH1lqDjCbTAOPfPuwaEgUF7jPIQxiAlOvcAw=="
        }
      }
    }
  ],
  "signatures": [
    "IKrnZXw/qzbDbCluHMhIYTObDVNsZljkOTOwtrS5I5kyN2ldyzGKkfIlpRCUPDVvTDjzaGwticly6aVTnujOaq0="
  ]
}

Base64:
CiISIIS_vios3nc0bp-j68lSWGCwrskINTvB0q1fBhNXobiCElEKBmZvb2JhchCAlOvcAxoCKBQiIhIgRxM86TfoWJVxsJc-loPg_SKyZkj0bFa-t7TVdknmDEEqGQAiEonCrriYm-jxFsfWWoOMJtMA498-7BoaTRJLChkALjP9GqkHsiTOnObJQiiQHSg6AtqVbaeREMrt1b8CGigKGQAiEonCrriYm-jxFsfWWoOMJtMA498-7BoSBQXuM8hDGICU69wDIkEgqudlfD-rNsNsKW4cyEhhM5sNU2xmWOQ5M7C2tLkjmTI3aV3LMYqR8iWlEJQ8NW9MOPNobC2JyXLppVOe6M5qrQ==
```

With fix:
```
🚫 🔓 📄 > session submit
JSON:
{
  "id": "0x122084bfbe2a2cde77346e9fa3ebc9525860b0aec908353bc1d2ad5f061357a1b882",
  "header": {
    "chain_id": "Zm9vYmFy",
    "rc_limit": "1000000000",
    "nonce": "KBQ=",
    "operation_merkle_root": "EiBHEzzpN-hYlXGwlz6Wg-D9IrJmSPRsVr63tNV2SeYMQQ==",
    "payer": "147ABaHVxtpoSpfpZ8yry7eaFAjV87trGR"
  },
  "operations": [
    {
      "call_contract": {
        "contract_id": "15DJN4a8SgrbGhhGksSBASiSYjGnMU8dGL",
        "entry_point": 670398154,
        "args": "ChkAIhKJwq64mJvo8RbH1lqDjCbTAOPfPuwaEgUF7jPIQxiAlOvcAw=="
      }
    }
  ],
  "signatures": [
    "IKrnZXw_qzbDbCluHMhIYTObDVNsZljkOTOwtrS5I5kyN2ldyzGKkfIlpRCUPDVvTDjzaGwticly6aVTnujOaq0="
  ]
}

Base64:
CiISIIS_vios3nc0bp-j68lSWGCwrskINTvB0q1fBhNXobiCElEKBmZvb2JhchCAlOvcAxoCKBQiIhIgRxM86TfoWJVxsJc-loPg_SKyZkj0bFa-t7TVdknmDEEqGQAiEonCrriYm-jxFsfWWoOMJtMA498-7BoaTRJLChkALjP9GqkHsiTOnObJQiiQHSg6AtqVbaeREMrt1b8CGigKGQAiEonCrriYm-jxFsfWWoOMJtMA498-7BoSBQXuM8hDGICU69wDIkEgqudlfD-rNsNsKW4cyEhhM5sNU2xmWOQ5M7C2tLkjmTI3aV3LMYqR8iWlEJQ8NW9MOPNobC2JyXLppVOe6M5qrQ==
```

Notice the contract ID, transaction ID, contract address, and payer address are all correctly formatted. Furthermore, the base64 encoded fields properly use the URL safe encoding.
