### PR TITLE
Implement signing of a transaction id

### DIFF
--- a/internal/cliutil/transaction.go
+++ b/internal/cliutil/transaction.go
@@ -106,3 +106,16 @@ func SignTransaction(key []byte, tx *protocol.Transaction) error {
 
 	return nil
 }
+
+// SignTransactionId signs the transaction ID with the given key
+func SignTransactionId(key []byte, tid []byte) ([]byte, error) {
+	privateKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), key)
+
+	// Decode to multihash ID
+	idBytes, err := multihash.Decode(tid)
+	if err != nil {
+		return nil, err
+	}
+
+	return btcec.SignCompact(btcec.S256(), privateKey, idBytes.Digest, true)
+}


### PR DESCRIPTION
Resolves <!-- Issue number(s) in the form #1 or org/repo#1 -->

## Brief description

Allows signing of a transaction ID directly to test signing using REST API 1.1

## Checklist

- [X] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
